### PR TITLE
Allow to disable restore on blur

### DIFF
--- a/src/jquery.placeholder.js
+++ b/src/jquery.placeholder.js
@@ -5,7 +5,8 @@
 				focusClass: 'placeholderFocus',
 				activeClass: 'placeholder',
 				overrideSupport: false,
-				preventRefreshIssues: true
+				preventRefreshIssues: true,
+				restoreOnBlur: true
 			},
 			debug : false,
 			log : function(msg){
@@ -94,7 +95,7 @@
                        .removeClass(opts.activeClass)
                        .addClass(opts.focusClass);
             });
-            $el.bind('blur.placeholder', function(){
+            $el.bind('placehold.placeholder', function(){
                 var $el = $(this);
 				
 				$el.removeClass(opts.focusClass);
@@ -103,8 +104,12 @@
                   $el.val($el.attr('placeholder'))
                      .addClass(opts.activeClass);
             });
+            $el.bind('blur.placeholder', function(){
+                if (opts.restoreOnBlur)
+                    $el.triggerHandler('placehold');
+            });
 
-            $el.triggerHandler('blur');
+            $el.triggerHandler('placehold');
 			
 			// Prevent incorrect form values being posted
 			$el.parents('form').submit(function(){


### PR DESCRIPTION
Hi,

Thanks for the awesome plugin - works a treat. I had a situation where I only wanted the placeholder to display on page load, and one the use has clicked into then out of it, it shouldn't come back. I couldn't find a way to do this so added in the restoreOnBlur option, which doesn't restore the placeholder on blur if it's set to false.

Feel free to pull it back to your version if you want - up to you.

Thanks,
Steve
